### PR TITLE
Fix broker consumer rewiring

### DIFF
--- a/src/amqplib_compat/broker.ts
+++ b/src/amqplib_compat/broker.ts
@@ -210,7 +210,7 @@ export default class NodeAmqpBroker {
     }
 
     this._channelConsumers.delete(ch);
-    this._channelConsumers.set(ch, set);
+    this._channelConsumers.set(newCh, set);
   }
 
   private async _startConsumer(ch: Channel, queue: string): Promise<Consumer> {


### PR DESCRIPTION
Do not lose the channel instance on channelConsumers map, which is used for rewiring consumers to new channels when old ones die.